### PR TITLE
Update documentation to reflect latest version / fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ Basic usage of this module is as follows:
 ```hcl
 module "composer" {
   source  = "terraform-google-modules/composer/google"
-  version = "~> 0.1"
+  version = "~> 2.0"
 
   project_id        = "<PROJECT ID>"
   region            = "us-central1"
   composer_env_name = "composer-env-test"
-  composer_sa       = "project-service-account@<PROJECT_ID>.iam.gserviceaccount.com"
   network           = "test-network"
   subnetwork        = "composer-subnet"
 }


### PR DESCRIPTION
As of 549ba6224c3e015028bffbf7fd204313179022d9 composer_sa
is no longer a required top level field for this module.
Also updates README to reflect latest module version.