### PR TITLE
add input variable enable_private_endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Functional examples are included in the
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | composer\_env\_name | Name of Cloud Composer Environment | `string` | n/a | yes |
-| enable\_private\_endpoint | enable\_private\_endpoint | `bool` | `false` | no |
+| enable\_private\_endpoint | Configure public access to the cluster endpoint. | `bool` | `false` | no |
 | network | Network where Cloud Composer is created. | `string` | n/a | yes |
 | project\_id | Project ID where Cloud Composer Environment is created. | `string` | n/a | yes |
 | region | Region where the Cloud Composer Environment is created. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -17,11 +17,11 @@
 module "composer-environment" {
   source = "./modules/create_environment_v1"
 
-  project_id        = var.project_id
-  composer_env_name = var.composer_env_name
-  region            = var.region
-  zone              = var.zone
-  network           = var.network
-  subnetwork        = var.subnetwork
+  project_id              = var.project_id
+  composer_env_name       = var.composer_env_name
+  region                  = var.region
+  zone                    = var.zone
+  network                 = var.network
+  subnetwork              = var.subnetwork
   enable_private_endpoint = var.enable_private_endpoint
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,6 @@ variable "subnetwork" {
 
 variable "enable_private_endpoint" {
   description = "Configure public access to the cluster endpoint."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
To configure public access to the cluster endpoint.
This feature it was already requested by user @lassebenni and
it's needed for many enterprise deployment.

Reference Issue #30 