### PR TITLE
fix dynamic master authorized networks

### DIFF
--- a/modules/create_environment_v2/main.tf
+++ b/modules/create_environment_v2/main.tf
@@ -138,8 +138,8 @@ resource "google_composer_environment" "composer_env" {
         dynamic "cidr_blocks" {
           for_each = master_authorized_networks_config.value["cidr_blocks"]
           content {
-            cidr_block   = master_authorized_networks_config.value["cidr_block"]
-            display_name = master_authorized_networks_config.value["display_name"]
+            cidr_block   = cidr_blocks.value["cidr_block"]
+            display_name = cidr_blocks.value["display_name"]
           }
         }
       }


### PR DESCRIPTION
This PR fixes adding authorized CIDR's to the GKE cluster created by Composer. The Dynamic block is incorrectly configured - this fixes that. 