### PR TITLE
chore: corrected errors in README example for `airflow_connection` module

### DIFF
--- a/modules/airflow_connection/README.md
+++ b/modules/airflow_connection/README.md
@@ -4,14 +4,14 @@ This optional module is used to create a Cloud Composer Connection.
 
 ```hcl
 module "connection" {
-  source      = "terraform-google-modules/composer/google//modules/airflow_connection"
-  project     = "project-123"
-  environment = "Composer-Prod-Env"
-  location    = "us-central1"
-  id          = "my-database"
-  host        = var.host
-  login       = var.user
-  password    = var.password
+  source            = "terraform-google-modules/composer/google//modules/airflow_connection"
+  project_id        = "project-123"
+  composer_env_name = "Composer-Prod-Env"
+  region            = "us-central1"
+  id                = "my-database"
+  host              = var.host
+  login             = var.user
+  password          = var.password
 }
 ```
 


### PR DESCRIPTION
The supplied example for this module was likely out of date from a previous version of the code. It references `project` instead of `project_id` and other similar examples.

This addresses those errors to make the example work.