### PR TITLE
chore: remove tests for composer env v1

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -82,7 +82,7 @@ steps:
 
 - id: converge airflow-connection-local
   waitFor:
-    - destroy-simple-composer-env-v2
+    - destroy-composer-v2-sharedvpc-prereq
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge airflow-connection-local']
 - id: verify airflow-connection-local
@@ -101,7 +101,7 @@ steps:
 
 - id: converge airflow-pool-local
   waitFor:
-    - destroy-simple-composer-env-v2
+    - destroy-composer-v2-sharedvpc-prereq
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge airflow-pool-local']
 - id: verify airflow-pool-local

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -96,24 +96,6 @@ steps:
 #   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
 #   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy airflow-connection-local']
 
-
-# ----- SUITE airflow-pool-local
-
-- id: converge airflow-pool-local
-  waitFor:
-    - destroy-composer-v2-sharedvpc-prereq
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge airflow-pool-local']
-- id: verify airflow-pool-local
-  waitFor:
-    - converge airflow-pool-local
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify airflow-pool-local']
-# - id: destroy airflow-pool-local
-#   waitFor:
-#     - verify airflow-pool-local
-#   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-#   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy airflow-pool-local']
 tags:
 - 'ci'
 - 'integration'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -78,33 +78,11 @@ steps:
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestSimpleComposerEnvV2SharedVpcModule --stage destroy --verbose']
 
-# ----- SUITE simple-composer-env-v1-local
-
-- id: init-simple-composer-env-v1
-  waitFor:
-    - destroy-simple-composer-env-v2
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSimpleComposerEnvV1Module --stage init --verbose']
-- id: apply-simple-composer-env-v1
-  waitFor:
-    - init-simple-composer-env-v1
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSimpleComposerEnvV1Module --stage apply --verbose']
-- id: verify-simple-composer-env-v1
-  waitFor:
-    - apply-simple-composer-env-v1
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSimpleComposerEnvV1Module --stage verify --verbose']
-- id: destroy-simple-composer-env-v1
-  waitFor:
-    - verify-simple-composer-env-v1
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSimpleComposerEnvV1Module --stage destroy --verbose']
 # ----- SUITE airflow-connection-local
 
 - id: converge airflow-connection-local
   waitFor:
-    - destroy-simple-composer-env-v1
+    - destroy-simple-composer-env-v2
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge airflow-connection-local']
 - id: verify airflow-connection-local
@@ -123,7 +101,7 @@ steps:
 
 - id: converge airflow-pool-local
   waitFor:
-    - destroy-simple-composer-env-v1
+    - destroy-simple-composer-env-v2
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge airflow-pool-local']
 - id: verify airflow-pool-local

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -78,24 +78,6 @@ steps:
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestSimpleComposerEnvV2SharedVpcModule --stage destroy --verbose']
 
-# ----- SUITE airflow-connection-local
-
-- id: converge airflow-connection-local
-  waitFor:
-    - destroy-composer-v2-sharedvpc-prereq
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge airflow-connection-local']
-- id: verify airflow-connection-local
-  waitFor:
-    - converge airflow-connection-local
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify airflow-connection-local']
-# - id: destroy airflow-connection-local
-#   waitFor:
-#     - verify airflow-connection-local
-#   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-#   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy airflow-connection-local']
-
 tags:
 - 'ci'
 - 'integration'


### PR DESCRIPTION
Removing tests for composer v1 as it is not [allowed in new projets](https://cloud.google.com/composer/docs/composer-versioning-overview#version-support-for-composer-1)


Starting February 27, 2024, in the us-central1, europe-west1, europe-west2, europe-west3, europe-west6, us-east1, and us-east4 regions it is `possible to create new Cloud Composer 1 environments only in projects that already have Cloud Composer 1 environments`