### PR TITLE
feat: adds var.enable_privately_used_public_ips to create_environment_v2

### DIFF
--- a/modules/create_environment_v2/README.md
+++ b/modules/create_environment_v2/README.md
@@ -31,6 +31,7 @@ module "simple-composer-environment" {
   enable_private_endpoint              = true
   use_private_environment              = true
   cloud_composer_connection_subnetwork = var.subnetwork_self_link
+  enable_privately_used_public_ips     = var.enable_privately_used_public_ips
 
   scheduler = {
     cpu        = 0.5
@@ -76,6 +77,7 @@ module "simple-composer-environment" {
 | composer\_service\_account | Service Account for running Cloud Composer. | `string` | `null` | no |
 | enable\_ip\_masq\_agent | Deploys 'ip-masq-agent' daemon set in the GKE cluster and defines nonMasqueradeCIDRs equals to pod IP range so IP masquerading is used for all destination addresses, except between pods traffic. | `bool` | `false` | no |
 | enable\_private\_endpoint | Configure private access to the cluster endpoint. If true, access to the public endpoint of the GKE cluster is denied | `bool` | `false` | no |
+| enable\_privately\_used\_public\_ips | When enabled, IPs from public (non-RFC1918) ranges can be used for ip\_allocation\_policy.cluster\_ipv4\_cidr\_block and ip\_allocation\_policy.service\_ipv4\_cidr\_block. | `bool` | `false` | no |
 | env\_variables | Variables of the airflow environment. | `map(string)` | `{}` | no |
 | environment\_size | The environment size controls the performance parameters of the managed Cloud Composer infrastructure that includes the Airflow database. Values for environment size are: `ENVIRONMENT_SIZE_SMALL`, `ENVIRONMENT_SIZE_MEDIUM`, and `ENVIRONMENT_SIZE_LARGE`. | `string` | `"ENVIRONMENT_SIZE_MEDIUM"` | no |
 | grant\_sa\_agent\_permission | Cloud Composer relies on Workload Identity as Google API authentication mechanism for Airflow. | `bool` | `true` | no |

--- a/modules/create_environment_v2/README.md
+++ b/modules/create_environment_v2/README.md
@@ -77,7 +77,7 @@ module "simple-composer-environment" {
 | composer\_service\_account | Service Account for running Cloud Composer. | `string` | `null` | no |
 | enable\_ip\_masq\_agent | Deploys 'ip-masq-agent' daemon set in the GKE cluster and defines nonMasqueradeCIDRs equals to pod IP range so IP masquerading is used for all destination addresses, except between pods traffic. | `bool` | `false` | no |
 | enable\_private\_endpoint | Configure private access to the cluster endpoint. If true, access to the public endpoint of the GKE cluster is denied | `bool` | `false` | no |
-| enable\_privately\_used\_public\_ips | When enabled, IPs from public (non-RFC1918) ranges can be used for ip\_allocation\_policy.cluster\_ipv4\_cidr\_block and ip\_allocation\_policy.service\_ipv4\_cidr\_block. | `bool` | `false` | no |
+| enable\_privately\_used\_public\_ips | When enabled, IPs from public (non-RFC1918) ranges can be used for pod_ip_allocation_range_name and service_ip_allocation_range_name. | `bool` | `false` | no |
 | env\_variables | Variables of the airflow environment. | `map(string)` | `{}` | no |
 | environment\_size | The environment size controls the performance parameters of the managed Cloud Composer infrastructure that includes the Airflow database. Values for environment size are: `ENVIRONMENT_SIZE_SMALL`, `ENVIRONMENT_SIZE_MEDIUM`, and `ENVIRONMENT_SIZE_LARGE`. | `string` | `"ENVIRONMENT_SIZE_MEDIUM"` | no |
 | grant\_sa\_agent\_permission | Cloud Composer relies on Workload Identity as Google API authentication mechanism for Airflow. | `bool` | `true` | no |

--- a/modules/create_environment_v2/README.md
+++ b/modules/create_environment_v2/README.md
@@ -77,7 +77,7 @@ module "simple-composer-environment" {
 | composer\_service\_account | Service Account for running Cloud Composer. | `string` | `null` | no |
 | enable\_ip\_masq\_agent | Deploys 'ip-masq-agent' daemon set in the GKE cluster and defines nonMasqueradeCIDRs equals to pod IP range so IP masquerading is used for all destination addresses, except between pods traffic. | `bool` | `false` | no |
 | enable\_private\_endpoint | Configure private access to the cluster endpoint. If true, access to the public endpoint of the GKE cluster is denied | `bool` | `false` | no |
-| enable\_privately\_used\_public\_ips | When enabled, IPs from public (non-RFC1918) ranges can be used for pod_ip_allocation_range_name and service_ip_allocation_range_name. | `bool` | `false` | no |
+| enable\_privately\_used\_public\_ips | When enabled, IPs from public (non-RFC1918) ranges can be used for pod\_ip\_allocation\_range\_name and service\_ip\_allocation\_range\_name. | `bool` | `false` | no |
 | env\_variables | Variables of the airflow environment. | `map(string)` | `{}` | no |
 | environment\_size | The environment size controls the performance parameters of the managed Cloud Composer infrastructure that includes the Airflow database. Values for environment size are: `ENVIRONMENT_SIZE_SMALL`, `ENVIRONMENT_SIZE_MEDIUM`, and `ENVIRONMENT_SIZE_LARGE`. | `string` | `"ENVIRONMENT_SIZE_MEDIUM"` | no |
 | grant\_sa\_agent\_permission | Cloud Composer relies on Workload Identity as Google API authentication mechanism for Airflow. | `bool` | `true` | no |

--- a/modules/create_environment_v2/main.tf
+++ b/modules/create_environment_v2/main.tf
@@ -86,6 +86,7 @@ resource "google_composer_environment" "composer_env" {
       for_each = var.use_private_environment ? [
         {
           enable_private_endpoint                = var.enable_private_endpoint
+          enable_privately_used_public_ips       = var.enable_privately_used_public_ips
           master_ipv4_cidr_block                 = var.master_ipv4_cidr
           cloud_sql_ipv4_cidr_block              = var.cloud_sql_ipv4_cidr
           cloud_composer_network_ipv4_cidr_block = var.cloud_composer_network_ipv4_cidr_block
@@ -93,6 +94,7 @@ resource "google_composer_environment" "composer_env" {
       }] : []
       content {
         enable_private_endpoint                = private_environment_config.value["enable_private_endpoint"]
+        enable_privately_used_public_ips       = private_environment_config.value["enable_privately_used_public_ips"]
         master_ipv4_cidr_block                 = private_environment_config.value["master_ipv4_cidr_block"]
         cloud_sql_ipv4_cidr_block              = private_environment_config.value["cloud_sql_ipv4_cidr_block"]
         cloud_composer_network_ipv4_cidr_block = private_environment_config.value["cloud_composer_network_ipv4_cidr_block"]

--- a/modules/create_environment_v2/variables.tf
+++ b/modules/create_environment_v2/variables.tf
@@ -142,6 +142,12 @@ variable "enable_private_endpoint" {
   default     = false
 }
 
+variable "enable_privately_used_public_ips" {
+  description = "When enabled, IPs from public (non-RFC1918) ranges can be used for ip_allocation_policy.cluster_ipv4_cidr_block and ip_allocation_policy.service_ipv4_cidr_block."
+  type        = bool
+  default     = false
+}
+
 variable "cloud_composer_network_ipv4_cidr_block" {
   description = "The CIDR block from which IP range in tenant project will be reserved. Required if VPC peering is used to connect to CloudSql instead of PSC"
   type        = string

--- a/modules/create_environment_v2/variables.tf
+++ b/modules/create_environment_v2/variables.tf
@@ -143,7 +143,7 @@ variable "enable_private_endpoint" {
 }
 
 variable "enable_privately_used_public_ips" {
-  description = "When enabled, IPs from public (non-RFC1918) ranges can be used for ip_allocation_policy.cluster_ipv4_cidr_block and ip_allocation_policy.service_ipv4_cidr_block."
+  description = "When enabled, IPs from public (non-RFC1918) ranges can be used for pod_ip_allocation_range_name and service_ip_allocation_range_name."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
adds var.enable_privately_used_public_ips to create_environment_v2 allowing public (non-RFC1918) ranges to be used.

closes https://github.com/terraform-google-modules/terraform-google-composer/issues/128
