### PR TITLE
feat: customize composer sa name in sub-module composer_net

### DIFF
--- a/modules/composer_net/README.md
+++ b/modules/composer_net/README.md
@@ -9,6 +9,7 @@ This example illustrates how to use the `composer-net` module. Please see exampl
 |------|-------------|------|---------|:--------:|
 | cloud\_composer\_network\_ipv4\_cidr\_block | The CIDR block from which IP range in tenant project will be reserved. | `string` | `null` | no |
 | composer\_env\_name | Name of Cloud Composer Environment | `string` | n/a | yes |
+| composer\_sa\_name | Service Account name to be used for running Cloud Composer Environment. | `string` | `"composer-sa"` | no |
 | dns\_zone\_name | Composer DNS private zone name | `string` | `"composer-google-cloud-dns"` | no |
 | gke\_pods\_services\_ip\_ranges | The secondary IP ranges for the GKE Pods and Services IP ranges | `list(string)` | n/a | yes |
 | gke\_subnet\_ip\_range | The GKE subnet IP range | `list(string)` | n/a | yes |

--- a/modules/composer_net/iam.tf
+++ b/modules/composer_net/iam.tf
@@ -38,8 +38,8 @@ Assign the Composer Worker (composer.worker) role.
 Assign the Service Account User (iam.serviceAccountUser) role
 ***/
 resource "google_service_account" "composer_sa" {
-  account_id   = "composer-sa"
-  display_name = "composer-sa"
+  account_id   = var.composer_sa_name
+  display_name = var.composer_sa_name
   project      = var.service_project_id
 }
 

--- a/modules/composer_net/variables.tf
+++ b/modules/composer_net/variables.tf
@@ -77,3 +77,9 @@ variable "dns_zone_name" {
   type        = string
   default     = "composer-google-cloud-dns"
 }
+
+variable "composer_sa_name" {
+  description = "Service Account name to be used for running Cloud Composer Environment."
+  type        = string
+  default     = "composer-sa"
+}


### PR DESCRIPTION
The ability to set the composer name service account instead of being hard coded on the module. 