### PR TITLE
feat: customize dns name in sub-module composer_net

### DIFF
--- a/modules/composer_net/README.md
+++ b/modules/composer_net/README.md
@@ -10,6 +10,7 @@ This example illustrates how to use the `composer-net` module. Please see exampl
 | cloud\_composer\_network\_ipv4\_cidr\_block | The CIDR block from which IP range in tenant project will be reserved. | `string` | `null` | no |
 | composer\_env\_name | Name of Cloud Composer Environment | `string` | n/a | yes |
 | composer\_sa\_name | Service Account name to be used for running Cloud Composer Environment. | `string` | `"composer-sa"` | no |
+| dns\_name | The DNS name of the managed zone | `string` | `"composer.cloud.google.com."` | no |
 | dns\_zone\_name | Composer DNS private zone name | `string` | `"composer-google-cloud-dns"` | no |
 | gke\_pods\_services\_ip\_ranges | The secondary IP ranges for the GKE Pods and Services IP ranges | `list(string)` | n/a | yes |
 | gke\_subnet\_ip\_range | The GKE subnet IP range | `list(string)` | n/a | yes |

--- a/modules/composer_net/dns.tf
+++ b/modules/composer_net/dns.tf
@@ -19,8 +19,8 @@ composer.cloud.google.com
 resource "google_dns_managed_zone" "composer_cloud_zone" {
   name        = var.dns_zone_name
   project     = var.network_project_id
-  dns_name    = "composer.cloud.google.com."
-  description = "composer.cloud.google.com zone"
+  dns_name    = var.dns_name
+  description = "${var.dns_name} zone"
 
   visibility = "private"
 
@@ -32,7 +32,7 @@ resource "google_dns_managed_zone" "composer_cloud_zone" {
 }
 
 resource "google_dns_record_set" "composer_cloud_zone-dev-A-record" {
-  name    = "composer.cloud.google.com."
+  name    = var.dns_name
   project = var.network_project_id
   type    = "A"
   ttl     = 300
@@ -43,12 +43,12 @@ resource "google_dns_record_set" "composer_cloud_zone-dev-A-record" {
 }
 
 resource "google_dns_record_set" "composer_cloud_zone-CNAME" {
-  name    = "*.composer.cloud.google.com."
+  name    = "*.${var.dns_name}"
   project = var.network_project_id
   type    = "CNAME"
   ttl     = 300
 
   managed_zone = google_dns_managed_zone.composer_cloud_zone.name
 
-  rrdatas = ["composer.cloud.google.com."]
+  rrdatas = [var.dns_name]
 }

--- a/modules/composer_net/variables.tf
+++ b/modules/composer_net/variables.tf
@@ -78,6 +78,12 @@ variable "dns_zone_name" {
   default     = "composer-google-cloud-dns"
 }
 
+variable "dns_name" {
+  description = "The DNS name of the managed zone"
+  type        = string
+  default     = "composer.cloud.google.com."
+}
+
 variable "composer_sa_name" {
   description = "Service Account name to be used for running Cloud Composer Environment."
   type        = string


### PR DESCRIPTION
The ability to customize DNS managed zone name instead of being hard coded.