### PR TITLE
fixes for airflow_pools submodule and update dependencies

### DIFF
--- a/modules/airflow_pool/README.md
+++ b/modules/airflow_pool/README.md
@@ -6,14 +6,19 @@ This optional module is used to create a Cloud Composer Pool.
 module "pool" {
   source      = "terraform-google-modules/composer/google//modules/airflow_pool"
 
-  project_id  = "project-123"
-  environment = "Composer-Prod-Env"
-  location    = "us-central1"
-  name        = "beta"
-  slots       = 1000
-  description = "Pool used by beta DAGs"
+  project           = "project-123"
+  environment       = "Composer-Prod-Env"
+  location          = "us-central1"
+  composer_env_name = "beta"
+  slot_count        = 1000
+  description       = "Pool used by beta DAGs"
 }
 ```
+
+> [!IMPORTANT]
+> to delete a pool you first need to run
+> ``` terraform destroy --target module.however_you_named_it ```
+> if you just remove the module configuration from your code the pool will not be deleted.
 
 ```
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -24,9 +29,10 @@ module "pool" {
 | composer\_env\_name | Name of the Cloud Composer Environment. | `string` | n/a | yes |
 | description | The description of the pool | `string` | `"Managed by Terraform"` | no |
 | pool\_name | The name of the pool | `string` | n/a | yes |
-| project\_id | Project ID where Cloud Composer Environment is created. | `string` | n/a | yes |
+| project | Project name where Cloud Composer Environment is created. | `string` | n/a | yes |
 | region | Region where the Cloud Composer Environment is created. | `string` | n/a | yes |
 | slot\_count | The number of slots in this pool | `number` | n/a | yes |
+| include_deferred | Whether the pool should include deferred tasks in its calculation of occupied slots | `bool` | false | no |
 
 ## Outputs
 

--- a/modules/airflow_pool/main.tf
+++ b/modules/airflow_pool/main.tf
@@ -15,9 +15,10 @@
  */
 
 locals {
-  gcloud_cmd_body  = "composer environments run --project=${var.project} --location=${var.region} ${var.composer_env_name} pools"
-  create_cmd_body  = "${local.gcloud_cmd_body} -- set ${jsonencode(var.pool_name)} ${jsonencode(var.slot_count)} ${jsonencode(var.description)}"
-  destroy_cmd_body = "${local.gcloud_cmd_body} -- delete ${jsonencode(var.pool_name)}"
+  include_deferred_flag = var.include_deferred ? " --include-deferred" : ""
+  gcloud_cmd_body       = "composer environments run --project=${var.project} --location=${var.region} ${var.composer_env_name} pools"
+  create_cmd_body       = "${local.gcloud_cmd_body} -- set ${jsonencode(var.pool_name)} ${jsonencode(var.slot_count)} ${jsonencode(var.description)} ${local.include_deferred_flag}"
+  destroy_cmd_body      = "${local.gcloud_cmd_body} -- delete ${jsonencode(var.pool_name)}"
 }
 
 module "gcloud" {

--- a/modules/airflow_pool/main.tf
+++ b/modules/airflow_pool/main.tf
@@ -15,14 +15,14 @@
  */
 
 locals {
-  gcloud_cmd_body  = "composer environments run --project=${var.project_id} --location=${var.region} ${var.composer_env_name} pool"
-  create_cmd_body  = "${local.gcloud_cmd_body} -- --set ${jsonencode(var.pool_name)} ${jsonencode(var.slot_count)} ${jsonencode(var.description)}"
-  destroy_cmd_body = "${local.gcloud_cmd_body} -- --delete ${jsonencode(var.pool_name)}"
+  gcloud_cmd_body  = "composer environments run --project=${var.project} --location=${var.region} ${var.composer_env_name} pools"
+  create_cmd_body  = "${local.gcloud_cmd_body} -- set ${jsonencode(var.pool_name)} ${jsonencode(var.slot_count)} ${jsonencode(var.description)}"
+  destroy_cmd_body = "${local.gcloud_cmd_body} -- delete ${jsonencode(var.pool_name)}"
 }
 
 module "gcloud" {
   source           = "terraform-google-modules/gcloud/google"
-  version          = "~> 3.1"
+  version          = "~> 4.0"
   platform         = "linux"
   create_cmd_body  = local.create_cmd_body
   destroy_cmd_body = local.destroy_cmd_body

--- a/modules/airflow_pool/variables.tf
+++ b/modules/airflow_pool/variables.tf
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-variable "project_id" {
+variable "project" {
   type        = string
-  description = "Project ID where Cloud Composer Environment is created."
+  description = "Project name where Cloud Composer Environment is created."
 }
 
 variable "region" {
@@ -37,6 +37,12 @@ variable "pool_name" {
 variable "slot_count" {
   type        = number
   description = "The number of slots in this pool"
+}
+
+variable "include_deferred" {
+  type        = bool
+  default     = false
+  description = "Whether the pool should include deferred tasks in its calculation of occupied slots"
 }
 
 variable "description" {


### PR DESCRIPTION
**Fixes:**

* fix the airflow CLI command (as far as I can determine from the airflow docs even in versions 1.x it was always ```airflow pools```, never ```pool```)
* rename the `project_id` variable to `project` (this is what the gcloud command uses and using _id when actually the name is required is misleading)

**New:**

* add optional variable `include_deferred` (defaults to false) to allow users to specify whether deferred tasks should be included in the pool's occupied slot calculation
* add a section in the README for how to correctly destroy a pool when using this module

**Updates:**

* update used the gcloud command terraform module from version `~> 3.1` to `~> 4.0`