### PR TITLE
fix(airflow_pool): use `pools` subcommand instead of deprecated `pool`

### DIFF
--- a/modules/airflow_pool/main.tf
+++ b/modules/airflow_pool/main.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  gcloud_cmd_body  = "composer environments run --project=${var.project_id} --location=${var.region} ${var.composer_env_name} pool"
+  gcloud_cmd_body  = "composer environments run --project=${var.project_id} --location=${var.region} ${var.composer_env_name} pools"
   create_cmd_body  = "${local.gcloud_cmd_body} -- --set ${jsonencode(var.pool_name)} ${jsonencode(var.slot_count)} ${jsonencode(var.description)}"
   destroy_cmd_body = "${local.gcloud_cmd_body} -- --delete ${jsonencode(var.pool_name)}"
 }

--- a/modules/airflow_pool/main.tf
+++ b/modules/airflow_pool/main.tf
@@ -16,8 +16,8 @@
 
 locals {
   gcloud_cmd_body  = "composer environments run --project=${var.project_id} --location=${var.region} ${var.composer_env_name} pools"
-  create_cmd_body  = "${local.gcloud_cmd_body} -- --set ${jsonencode(var.pool_name)} ${jsonencode(var.slot_count)} ${jsonencode(var.description)}"
-  destroy_cmd_body = "${local.gcloud_cmd_body} -- --delete ${jsonencode(var.pool_name)}"
+  create_cmd_body  = "${local.gcloud_cmd_body} -- set ${jsonencode(var.pool_name)} ${jsonencode(var.slot_count)} ${jsonencode(var.description)}"
+  destroy_cmd_body = "${local.gcloud_cmd_body} -- delete ${jsonencode(var.pool_name)}"
 }
 
 module "gcloud" {

--- a/test/integration/airflow-pool/controls/airflow-pool.rb
+++ b/test/integration/airflow-pool/controls/airflow-pool.rb
@@ -47,9 +47,7 @@ control "Cloud Composer Environment" do
         end
     end
 
-    # TODO: Use 'pools -- list' instead of 'pool' so it will work with Airflow v2.
-    # The command is being wrongly reported as incompatible (See Google support case 29006802)
-    describe command("gcloud composer environments run #{attribute("composer_env_name")} --location=us-central1 --project=#{attribute("project_id")} pool") do
+    describe command("gcloud composer environments run #{attribute("composer_env_name")} --location=us-central1 --project=#{attribute("project_id")} pools -- list") do
         its(:exit_status) { should eq 0 }
 
         let!(:data) do


### PR DESCRIPTION
The Airflow CLI renamed the `pool` subcommand to [`pools`](https://airflow.apache.org/docs/apache-airflow/2.7.3/cli-and-env-variables-ref.html#pools) in 1.10.14 and removed the old name in 2.0.0. Since Cloud Composer 2+ only runs Airflow 2.x, the old subcommand name never works. See [Airflow CLI changes in 2.0](https://airflow.apache.org/docs/apache-airflow/2.0.0/upgrading-to-2.html#id12)