### PR TITLE
feat(create_environment_v3): support airflow_metadata_retention_config

### DIFF
--- a/modules/create_environment_v3/README.md
+++ b/modules/create_environment_v3/README.md
@@ -64,6 +64,7 @@ module "simple-composer-environment" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | airflow\_config\_overrides | Airflow configuration properties to override. Property keys contain the section and property names, separated by a hyphen, for example "core-dags\_are\_paused\_at\_creation". | `map(string)` | `{}` | no |
+| airflow\_metadata\_retention\_config | The retention policy for the Airflow metadata database. retention\_mode can be RETENTION\_MODE\_ENABLED or RETENTION\_MODE\_DISABLED. retention\_days sets how many days metadata is retained when retention is enabled. Cloud Composer 2.0.31 or newer only | <pre>object({<br>    retention_mode = optional(string, "RETENTION_MODE_ENABLED")<br>    retention_days = optional(number, 30)<br>  })</pre> | `null` | no |
 | cloud\_data\_lineage\_integration | Whether or not Dataplex data lineage integration is enabled. Cloud Composer environments in versions composer-2.1.2-airflow-..* and newer) | `bool` | `false` | no |
 | composer\_env\_name | Name of Cloud Composer Environment | `string` | n/a | yes |
 | composer\_network\_attachment\_name | Name for PSC (Private Service Connect) Network entry point. | `string` | `null` | no |

--- a/modules/create_environment_v3/main.tf
+++ b/modules/create_environment_v3/main.tf
@@ -178,10 +178,22 @@ resource "google_composer_environment" "composer_env" {
     }
 
     dynamic "data_retention_config" {
-      for_each = var.task_logs_retention_storage_mode == null ? [] : ["data_retention_config"]
+
+      for_each = (var.task_logs_retention_storage_mode != null || var.airflow_metadata_retention_config != null) ? ["data_retention_config"] : []
       content {
-        task_logs_retention_config {
-          storage_mode = var.task_logs_retention_storage_mode
+
+        dynamic "task_logs_retention_config" {
+          for_each = var.task_logs_retention_storage_mode != null ? ["task_logs_retention_config"] : []
+          content {
+            storage_mode = var.task_logs_retention_storage_mode
+          }
+        }
+        dynamic "airflow_metadata_retention_config" {
+          for_each = var.airflow_metadata_retention_config != null ? [var.airflow_metadata_retention_config] : []
+          content {
+            retention_mode = airflow_metadata_retention_config.value["retention_mode"]
+            retention_days = airflow_metadata_retention_config.value["retention_days"]
+          }
         }
       }
     }

--- a/modules/create_environment_v3/variables.tf
+++ b/modules/create_environment_v3/variables.tf
@@ -277,3 +277,11 @@ variable "task_logs_retention_storage_mode" {
   type        = string
   default     = null
 }
+variable "airflow_metadata_retention_config" {
+  type = object({
+    retention_mode = optional(string, "RETENTION_MODE_ENABLED")
+    retention_days = optional(number, 30)
+  })
+  default     = null
+  description = "The retention policy for the Airflow metadata database. retention_mode can be RETENTION_MODE_ENABLED or RETENTION_MODE_DISABLED. retention_days sets how many days metadata is retained when retention is enabled. Cloud Composer 2.0.31 or newer only"
+}


### PR DESCRIPTION
## Description

The `create_environment_v3` module exposes `data_retention_config` but only
supports the `task_logs_retention_config` sub-block. This PR adds support for
`airflow_metadata_retention_config`, which the underlying
`google_composer_environment` resource supports on Cloud Composer 2.0.31+ and
Composer 3.

### Changes

- Add optional `airflow_metadata_retention_config` variable
  (`retention_mode`, `retention_days`).
- Convert the existing hardcoded `task_logs_retention_config` into a dynamic
  block and add a parallel dynamic `airflow_metadata_retention_config` block.
- Update the parent `data_retention_config` `for_each` so it renders when
  either sub-config is set.

### Backwards compatibility

Fully backwards compatible. The new variable defaults to `null`, so the block
is only emitted when explicitly configured. Existing callers setting only
`task_logs_retention_storage_mode` are unaffected.

### Testing

- `terraform fmt` 
- `make generate_docs` run to refresh the README inputs table.