### PR TITLE
fix!: Change disabling cloud_data_lineage_integration default value to null

### DIFF
--- a/examples/simple_composer_env_v2/main.tf
+++ b/examples/simple_composer_env_v2/main.tf
@@ -52,7 +52,7 @@ module "simple-composer-environment" {
   enable_private_endpoint              = true
   use_private_environment              = true
   cloud_composer_connection_subnetwork = var.subnetwork_self_link
-  cloud_data_lineage_integration       = true
+  cloud_data_lineage_integration       = false
   resilience_mode                      = "STANDARD_RESILIENCE"
 
   scheduler = {

--- a/modules/create_environment_v2/README.md
+++ b/modules/create_environment_v2/README.md
@@ -71,7 +71,7 @@ module "simple-composer-environment" {
 | airflow\_config\_overrides | Airflow configuration properties to override. Property keys contain the section and property names, separated by a hyphen, for example "core-dags\_are\_paused\_at\_creation". | `map(string)` | `{}` | no |
 | cloud\_composer\_connection\_subnetwork | Subnetwork self-link. When specified, the environment will use Private Service Connect instead of VPC peerings to connect to CloudSQL in the Tenant Project. IP address of psc endpoint is allocated from this subnet | `string` | `null` | no |
 | cloud\_composer\_network\_ipv4\_cidr\_block | The CIDR block from which IP range in tenant project will be reserved. Required if VPC peering is used to connect to CloudSql instead of PSC | `string` | `null` | no |
-| cloud\_data\_lineage\_integration | Whether or not Dataplex data lineage integration is enabled. Cloud Composer environments in versions composer-2.1.2-airflow-..* and newer) | `bool` | `false` | no |
+| cloud\_data\_lineage\_integration | Whether or not Dataplex data lineage integration is enabled. Set to true or false to explicitly manage it; leave null to not manage the setting. Cloud Composer environments in versions composer-2.1.2-airflow-..* and newer) | `bool` | `null` | no |
 | cloud\_sql\_ipv4\_cidr | The CIDR block from which IP range in tenant project will be reserved for Cloud SQL private service access. Required if VPC peering is used to connect to CloudSql instead of PSC | `string` | `null` | no |
 | composer\_env\_name | Name of Cloud Composer Environment | `string` | n/a | yes |
 | composer\_service\_account | Service Account for running Cloud Composer. | `string` | `null` | no |

--- a/modules/create_environment_v2/main.tf
+++ b/modules/create_environment_v2/main.tf
@@ -74,7 +74,7 @@ resource "google_composer_environment" "composer_env" {
         env_variables            = software_config.value["env_variables"]
         image_version            = software_config.value["image_version"]
         dynamic "cloud_data_lineage_integration" {
-          for_each = var.cloud_data_lineage_integration ? ["cloud_data_lineage_integration"] : []
+          for_each = var.cloud_data_lineage_integration != null ? ["cloud_data_lineage_integration"] : []
           content {
             enabled = var.cloud_data_lineage_integration
           }

--- a/modules/create_environment_v2/variables.tf
+++ b/modules/create_environment_v2/variables.tf
@@ -275,9 +275,9 @@ variable "resilience_mode" {
 }
 
 variable "cloud_data_lineage_integration" {
-  description = "Whether or not Dataplex data lineage integration is enabled. Cloud Composer environments in versions composer-2.1.2-airflow-..* and newer)"
+  description = "Whether or not Dataplex data lineage integration is enabled. Set to true or false to explicitly manage it; leave null to not manage the setting. Cloud Composer environments in versions composer-2.1.2-airflow-..* and newer)"
   type        = bool
-  default     = false
+  default     = null
 }
 
 variable "web_server_network_access_control" {

--- a/modules/create_environment_v3/README.md
+++ b/modules/create_environment_v3/README.md
@@ -64,7 +64,7 @@ module "simple-composer-environment" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | airflow\_config\_overrides | Airflow configuration properties to override. Property keys contain the section and property names, separated by a hyphen, for example "core-dags\_are\_paused\_at\_creation". | `map(string)` | `{}` | no |
-| cloud\_data\_lineage\_integration | Whether or not Dataplex data lineage integration is enabled. Cloud Composer environments in versions composer-2.1.2-airflow-..* and newer) | `bool` | `false` | no |
+| cloud\_data\_lineage\_integration | Whether or not Dataplex data lineage integration is enabled. Set to true or false to explicitly manage it; leave null to not manage the setting. Cloud Composer environments in versions composer-2.1.2-airflow-..* and newer) | `bool` | `null` | no |
 | composer\_env\_name | Name of Cloud Composer Environment | `string` | n/a | yes |
 | composer\_network\_attachment\_name | Name for PSC (Private Service Connect) Network entry point. | `string` | `null` | no |
 | composer\_service\_account | Service Account for running Cloud Composer. | `string` | `null` | no |

--- a/modules/create_environment_v3/main.tf
+++ b/modules/create_environment_v3/main.tf
@@ -67,7 +67,7 @@ resource "google_composer_environment" "composer_env" {
         image_version            = software_config.value["image_version"]
         web_server_plugins_mode  = software_config.value["web_server_plugins_mode"]
         dynamic "cloud_data_lineage_integration" {
-          for_each = var.cloud_data_lineage_integration ? ["cloud_data_lineage_integration"] : []
+          for_each = var.cloud_data_lineage_integration != null ? ["cloud_data_lineage_integration"] : []
           content {
             enabled = var.cloud_data_lineage_integration
           }

--- a/modules/create_environment_v3/variables.tf
+++ b/modules/create_environment_v3/variables.tf
@@ -252,9 +252,9 @@ variable "resilience_mode" {
 }
 
 variable "cloud_data_lineage_integration" {
-  description = "Whether or not Dataplex data lineage integration is enabled. Cloud Composer environments in versions composer-2.1.2-airflow-..* and newer)"
+  description = "Whether or not Dataplex data lineage integration is enabled. Set to true or false to explicitly manage it; leave null to not manage the setting. Cloud Composer environments in versions composer-2.1.2-airflow-..* and newer)"
   type        = bool
-  default     = false
+  default     = null
 }
 
 variable "web_server_network_access_control" {

--- a/test/integration/simple-composer-env-v2/simple_composer_env_v2_test.go
+++ b/test/integration/simple-composer-env-v2/simple_composer_env_v2_test.go
@@ -36,6 +36,7 @@ func TestSimpleComposerEnvV2Module(t *testing.T) {
 		assert.Equal(composer.GetStringOutput("airflow_uri"), op.Get("config.airflowUri").String(), "AirflowUri is valid")
 		assert.Equal(composer.GetStringOutput("gke_cluster"), op.Get("config.gkeCluster").String(), "GKE Cluster is valid")
 		assert.Equal(composer.GetStringOutput("gcs_bucket"), op.Get("config.dagGcsPrefix").String(), "GCS-Dag is valid")
+		assert.False(op.Get("config.softwareConfig.cloudDataLineageIntegration.enabled").Bool(), "Cloud Data Lineage Integration is disabled")
 	})
 	composer.Test()
 }

--- a/test/integration/simple_composer_env_v3/simple_composer_env_v3_test.go
+++ b/test/integration/simple_composer_env_v3/simple_composer_env_v3_test.go
@@ -35,6 +35,7 @@ func TestSimpleComposerEnvV3Module(t *testing.T) {
 		assert.Equal(fmt.Sprintf("projects/%s/locations/us-central1/environments/%s", projectID, composer.GetStringOutput("composer_env_name")), op.Get("name").String(), "Composer name is valid")
 		assert.Equal(composer.GetStringOutput("airflow_uri"), op.Get("config.airflowUri").String(), "AirflowUri is valid")
 		assert.Equal(composer.GetStringOutput("gcs_bucket"), op.Get("config.dagGcsPrefix").String(), "GCS-Dag is valid")
+		assert.True(op.Get("config.softwareConfig.cloudDataLineageIntegration.enabled").Bool(), "Cloud Data Lineage Integration is enabled")
 	})
 	composer.Test()
 }


### PR DESCRIPTION
## Description

Fixes #198

`cloud_data_lineage_integration = false` was a no-op: the dynamic block was only emitted when the value was `true`, so `enabled = false` was never sent to the API and the integration could not be turned off through the module (also reported in #143, #172).

## Root Cause

In `create_environment_v2` and `create_environment_v3`, the block used `for_each = var.cloud_data_lineage_integration ? [...] : []`, so a `false` value produced an empty `for_each` and the block was omitted entirely.

## Solution

Make the variable nullable (`default = null`) and gate the block on `!= null`, so both `true` and `false` emit the block with the user's value while `null` leaves the setting unmanaged.

## Testing

- Set `cloud_data_lineage_integration = false` in the `simple_composer_env_v2` example and assert the environment reports lineage disabled (the blueprint idempotency check also confirms the false value round-trips without drift).
- `simple_composer_env_v3` keeps `true` and asserts lineage enabled.
- `terraform validate` passes on both modules; `go vet` passes on the updated tests.
