### PR TITLE
feat: add Airflow metadata retention config for Composer v3

### DIFF
--- a/examples/simple_composer_env_v3/main.tf
+++ b/examples/simple_composer_env_v3/main.tf
@@ -82,4 +82,9 @@ module "simple-composer-environment" {
   ]
 
   image_version = "composer-3-airflow-3"
+
+  airflow_metadata_retention_config = {
+    retention_mode = "RETENTION_MODE_ENABLED"
+    retention_days = 90
+  }
 }

--- a/modules/create_environment_v3/README.md
+++ b/modules/create_environment_v3/README.md
@@ -64,6 +64,7 @@ module "simple-composer-environment" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | airflow\_config\_overrides | Airflow configuration properties to override. Property keys contain the section and property names, separated by a hyphen, for example "core-dags\_are\_paused\_at\_creation". | `map(string)` | `{}` | no |
+| airflow\_metadata\_retention\_config | The retention policy for the Airflow metadata database. retention\_mode is RETENTION\_MODE\_ENABLED or RETENTION\_MODE\_DISABLED. retention\_days is how many days data must be retained (30-730). Requires Terraform Google Provider 6.15 or newer. | <pre>object({<br>    retention_mode = string<br>    retention_days = optional(number)<br>  })</pre> | `null` | no |
 | cloud\_data\_lineage\_integration | Whether or not Dataplex data lineage integration is enabled. Cloud Composer environments in versions composer-2.1.2-airflow-..* and newer) | `bool` | `false` | no |
 | composer\_env\_name | Name of Cloud Composer Environment | `string` | n/a | yes |
 | composer\_network\_attachment\_name | Name for PSC (Private Service Connect) Network entry point. | `string` | `null` | no |

--- a/modules/create_environment_v3/main.tf
+++ b/modules/create_environment_v3/main.tf
@@ -18,6 +18,8 @@ locals {
   network_project_id = var.network_project_id != "" ? var.network_project_id : var.project_id
   subnetwork_region  = var.subnetwork_region != "" ? var.subnetwork_region : var.region
   cloud_composer_sa  = format("service-%s@cloudcomposer-accounts.iam.gserviceaccount.com", data.google_project.project.number)
+
+  data_retention_config_enabled = var.task_logs_retention_storage_mode != null || var.airflow_metadata_retention_config != null
 }
 
 resource "google_composer_environment" "composer_env" {
@@ -178,10 +180,21 @@ resource "google_composer_environment" "composer_env" {
     }
 
     dynamic "data_retention_config" {
-      for_each = var.task_logs_retention_storage_mode == null ? [] : ["data_retention_config"]
+      for_each = local.data_retention_config_enabled ? ["data_retention_config"] : []
       content {
-        task_logs_retention_config {
-          storage_mode = var.task_logs_retention_storage_mode
+        dynamic "task_logs_retention_config" {
+          for_each = var.task_logs_retention_storage_mode == null ? [] : ["task_logs_retention_config"]
+          content {
+            storage_mode = var.task_logs_retention_storage_mode
+          }
+        }
+
+        dynamic "airflow_metadata_retention_config" {
+          for_each = var.airflow_metadata_retention_config == null ? [] : ["airflow_metadata_retention_config"]
+          content {
+            retention_mode = var.airflow_metadata_retention_config.retention_mode
+            retention_days = var.airflow_metadata_retention_config.retention_days
+          }
         }
       }
     }

--- a/modules/create_environment_v3/variables.tf
+++ b/modules/create_environment_v3/variables.tf
@@ -277,3 +277,28 @@ variable "task_logs_retention_storage_mode" {
   type        = string
   default     = null
 }
+
+variable "airflow_metadata_retention_config" {
+  description = "The retention policy for the Airflow metadata database. retention_mode is RETENTION_MODE_ENABLED or RETENTION_MODE_DISABLED. retention_days is how many days data must be retained (30-730). Requires Terraform Google Provider 6.15 or newer."
+  type = object({
+    retention_mode = string
+    retention_days = optional(number)
+  })
+  default = null
+
+  validation {
+    condition = var.airflow_metadata_retention_config == null || contains(
+      ["RETENTION_MODE_ENABLED", "RETENTION_MODE_DISABLED"],
+      var.airflow_metadata_retention_config.retention_mode
+    )
+    error_message = "airflow_metadata_retention_config.retention_mode must be RETENTION_MODE_ENABLED or RETENTION_MODE_DISABLED."
+  }
+
+  validation {
+    condition = var.airflow_metadata_retention_config == null || var.airflow_metadata_retention_config.retention_days == null || (
+      var.airflow_metadata_retention_config.retention_days >= 30 &&
+      var.airflow_metadata_retention_config.retention_days <= 730
+    )
+    error_message = "airflow_metadata_retention_config.retention_days must be between 30 and 730."
+  }
+}

--- a/modules/create_environment_v3/versions.tf
+++ b/modules/create_environment_v3/versions.tf
@@ -20,12 +20,12 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.0, < 8"
+      version = ">= 6.15, < 8"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.0, < 8"
+      version = ">= 6.15, < 8"
     }
   }
 

--- a/test/integration/simple_composer_env_v3/simple_composer_env_v3_test.go
+++ b/test/integration/simple_composer_env_v3/simple_composer_env_v3_test.go
@@ -35,6 +35,8 @@ func TestSimpleComposerEnvV3Module(t *testing.T) {
 		assert.Equal(fmt.Sprintf("projects/%s/locations/us-central1/environments/%s", projectID, composer.GetStringOutput("composer_env_name")), op.Get("name").String(), "Composer name is valid")
 		assert.Equal(composer.GetStringOutput("airflow_uri"), op.Get("config.airflowUri").String(), "AirflowUri is valid")
 		assert.Equal(composer.GetStringOutput("gcs_bucket"), op.Get("config.dagGcsPrefix").String(), "GCS-Dag is valid")
+		assert.Equal("RETENTION_MODE_ENABLED", op.Get("config.dataRetentionConfig.airflowMetadataRetentionConfig.retentionMode").String(), "Airflow metadata retention mode is valid")
+		assert.Equal("90", op.Get("config.dataRetentionConfig.airflowMetadataRetentionConfig.retentionDays").String(), "Airflow metadata retention days are valid")
 	})
 	composer.Test()
 }


### PR DESCRIPTION
## Summary
- Add optional `airflow_metadata_retention_config` to `create_environment_v3` (`retention_mode` and `retention_days`).
- Raise the v3 module Google provider floor to 6.15, when this field was added.
- Enable 90-day metadata retention in the v3 example and assert it in the integration test.

## Test plan
- [x] Regenerated module docs (`generate_docs`)
- [x] `terraform validate` on `modules/create_environment_v3`
- [ ] CI lint
- [ ] Integration tests via maintainer `/gcbrun`


Made with [Cursor](https://cursor.com)